### PR TITLE
Clean finalizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ coverage.txt
 *.log
 
 *.local.yaml
+
+.vscode

--- a/controller/controllers/component_controller.go
+++ b/controller/controllers/component_controller.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	js "github.com/dop251/goja"
 	"github.com/kalmhq/kalm/controller/lib/files"
-	"github.com/kalmhq/kalm/controller/utils"
 	"github.com/kalmhq/kalm/controller/vm"
 	"github.com/xeipuuv/gojsonschema"
 	appsV1 "k8s.io/api/apps/v1"
@@ -1327,34 +1326,6 @@ func (r *ComponentReconcilerTask) decideAffinity() (*coreV1.Affinity, bool) {
 		NodeAffinity:    nodeAffinity,
 		PodAntiAffinity: podAntiAffinity,
 	}, true
-}
-
-func (r *ComponentReconcilerTask) HandleDelete() (err error) {
-
-	if r.component.ObjectMeta.DeletionTimestamp.IsZero() {
-		if !utils.ContainsString(r.component.ObjectMeta.Finalizers, finalizerName) {
-			r.component.ObjectMeta.Finalizers = append(r.component.ObjectMeta.Finalizers, finalizerName)
-			if err := r.Update(context.Background(), r.component); err != nil {
-				return err
-			}
-		}
-	} else {
-		if utils.ContainsString(r.component.ObjectMeta.Finalizers, finalizerName) {
-			// TODO remove resources
-			if err := r.DeleteResources(); client.IgnoreNotFound(err) != nil {
-				r.WarningEvent(err, "fail when DeleteResources")
-				return err
-			}
-
-			r.component.ObjectMeta.Finalizers = utils.RemoveString(r.component.ObjectMeta.Finalizers, finalizerName)
-			if err := r.Update(r.ctx, r.component); err != nil {
-				r.WarningEvent(err, "fail when update component")
-				return err
-			}
-		}
-	}
-
-	return nil
 }
 
 func (r *ComponentReconcilerTask) SetupAttributes(req ctrl.Request) (err error) {

--- a/controller/controllers/helper_test.go
+++ b/controller/controllers/helper_test.go
@@ -70,18 +70,7 @@ func (suite *BasicSuite) createComponentPlugin(plugin *v1alpha1.ComponentPlugin)
 	// after the finalizer is set, the plugin won't auto change
 	suite.Eventually(func() bool {
 		err := suite.K8sClient.Get(context.Background(), getComponentPluginNamespacedName(plugin), plugin)
-
-		if err != nil {
-			return false
-		}
-
-		for i := range plugin.Finalizers {
-			if plugin.Finalizers[i] == finalizerName {
-				return true
-			}
-		}
-
-		return false
+		return err == nil
 	})
 }
 
@@ -106,26 +95,6 @@ func (suite *BasicSuite) createComponentPlugin(plugin *v1alpha1.ComponentPlugin)
 //	})
 //}
 
-//func (suite *BasicSuite) createApplication(ns *v1alpha1.Application) {
-//	suite.Nil(suite.K8sClient.Create(context.Background(), ns))
-//
-//	suite.Eventually(func() bool {
-//		err := suite.K8sClient.Get(context.Background(), getApplicationNamespacedName(ns), ns)
-//
-//		if err != nil {
-//			return false
-//		}
-//
-//		for i := range ns.Finalizers {
-//			if ns.Finalizers[i] == finalizerName {
-//				return true
-//			}
-//		}
-//
-//		return false
-//	}, "Created ns has no finalizer.")
-//}
-
 func getDockerRegistryNamespacedName(registry *v1alpha1.DockerRegistry) types.NamespacedName {
 	return types.NamespacedName{Name: registry.Name, Namespace: registry.Namespace}
 }
@@ -136,17 +105,7 @@ func (suite *BasicSuite) createDockerRegistry(registry *v1alpha1.DockerRegistry)
 	suite.Eventually(func() bool {
 		err := suite.K8sClient.Get(context.Background(), getDockerRegistryNamespacedName(registry), registry)
 
-		if err != nil {
-			return false
-		}
-
-		for i := range registry.Finalizers {
-			if registry.Finalizers[i] == finalizerName {
-				return true
-			}
-		}
-
-		return false
+		return err == nil
 	}, "Created Docker registry has no finalizer.")
 }
 
@@ -315,8 +274,12 @@ func randomName() string {
 	return string(b)
 }
 
-func (suite *BasicSuite) SetupKalmEnabledNs(name string) v1.Namespace {
-	if name == "" {
+func (suite *BasicSuite) SetupKalmEnabledNs(nameOpt ...string) v1.Namespace {
+	var name string
+
+	if len(nameOpt) > 0 && nameOpt[0] != "" {
+		name = nameOpt[0]
+	} else {
 		name = randomName()
 	}
 


### PR DESCRIPTION
the only remaining finalizer is for ComponentPlugin, it will clean pluginBindings if a ComponentPlugin is deleted.

component owns pluginBinding, if a component is deleted, it's owned bindings will be auto-deleted


based on branch: no-enq-req-for-obj