### PR TITLE
Some minor visual modifications to Installation Script 

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "setup Kalm"
+echo "Installing Kalm"
 echo ""
 
 kubectl apply -f https://raw.githubusercontent.com/kalmhq/kalm/master/kalm-install-operator.yaml
@@ -12,7 +12,7 @@ CRD_NAMES_ACCEPTED=""
 
 while [ "$CRD_ESTABLISHED" != "True" ] || [ "$CRD_NAMES_ACCEPTED" != "True" ]
 do
-  echo -e "\nwaiting for installation of CRD..."
+  echo -e "\nAwaiting installation of CRDs"
   #sleep 1
 
   CRD_ESTABLISHED=$(kubectl get crd kalmoperatorconfigs.install.kalm.dev -ojsonpath='{.status.conditions[?(@.type=="Established")].status}')
@@ -29,19 +29,30 @@ do
   OPERATOR_CONFIG_APPLY_STATUS=$?
 done
 
-echo -e "\n🎉 operator installed, start monitoring installation of Kalm"
 sleep 1
 
 finish=False
 
+function printCompletedItems() {
+  Green='\033[0;32m' 
+  OFF='\033[0m' 
+
+  clear
+  echo "Initializing Kalm - ${#installed[@]}/${#ns_array[@]} modules ready:"
+  echo ""
+  
+  for i in "${installed[@]}"
+  do
+    echo -e "${Green}✔${OFF} $i"
+  done
+}
+
+
+
 while [ $finish != "True" ]
 do
-    clear 
-
     installing=()
-
-    echo "Installing Kalm, this outputs deployments status in all Kalm related namespaces"
-    echo ""
+    installed=()
 
     ns_array=(kalm-operator cert-manager istio-system kalm-system)
     dp_cnt_array=(1 3 3 2)
@@ -52,8 +63,8 @@ do
         ns=${ns_array[i]}
         dp_cnt=${dp_cnt_array[i]}
 
-        kubectl get deployments.apps -n $ns
-        echo ""
+        # kubectl get deployments.apps -n $ns
+        # echo ""
     
         dp_status_output=$(kubectl get deployments.apps -n $ns -ojsonpath='{.items[*].status.conditions[?(@.type=="Available")].status}')
         dp_status_list=($dp_status_output)
@@ -70,6 +81,7 @@ do
             do
                 if [ $status == "True" ]
                 then
+                    installed+=($ns)
                     continue
                 fi
     
@@ -80,12 +92,21 @@ do
     done
     
     installing_list_size=${#installing[@]}
+
+    printCompletedItems "${installed[@]}"
     if [ $installing_list_size -gt 0 ]
     then
-        echo "⌛ waiting for installing of: ${installing[@]}"
+        # echo "⌛ waiting for installing of: ${installing[@]}"
         sleep 3
     else
+        echo "Kalm Installation Complete! 🎉"
+        echo ""
+        echo "To start using Kalm, open a port via:"
+        echo ""
+        echo "kubectl port-forward -n kalm-system \$(kubectl get pod -n kalm-system -l app=kalm -ojsonpath=\"{.items[0].metadata.name}\") 3001:3001"
+        echo ""
+        echo "Then visit http://localhost:3001 in your browser"
+        echo ""
         finish="True"
-        echo "🎉 installing done"
     fi
 done


### PR DESCRIPTION
I mostly needed to fix 1-2 minor typos before taking screenshots for the Installation Documentation. Tried out a few changes while looking at the script:

- Improved existing wording
- Stopped printing via kubectl which caused screen to constantly flicker
- Instead print a short checklist
- Print out some post-installation instructions(port forward, open
localhost:3001)

It looks like this:

![Screenshot from 2020-08-05 16-49-05](https://user-images.githubusercontent.com/67806321/89476265-1dbc1b80-d73f-11ea-969a-9657a8cc6e75.png)

![Screenshot from 2020-08-05 17-14-47](https://user-images.githubusercontent.com/67806321/89476308-37f5f980-d73f-11ea-9e23-7c1292a544d8.png)
