### PR TITLE
change volumes api unit from string to quantity

### DIFF
--- a/frontend/src/forms/Basic/textfield.tsx
+++ b/frontend/src/forms/Basic/textfield.tsx
@@ -135,7 +135,7 @@ export class RenderFormikComplexValueTextField extends React.PureComponent<
       min,
       endAdornment,
       field: { name, value },
-      form: { touched, errors, setFieldValue },
+      form: { touched, errors, setFieldValue, setFieldTouched },
       format,
       parse,
     } = this.props;
@@ -170,8 +170,11 @@ export class RenderFormikComplexValueTextField extends React.PureComponent<
         defaultValue={format ? format(value) : value}
         // value={format ? format(value) : value}
         onBlur={(e) => {
+          setFieldTouched(name, true);
+        }}
+        onChange={(e) => {
           const value = e.target.value;
-          return parse ? setFieldValue(name, parse(value)) : setFieldValue(name, value);
+          parse ? setFieldValue(name, parse(value)) : setFieldValue(name, value);
         }}
       />
     );

--- a/frontend/src/forms/validator.ts
+++ b/frontend/src/forms/validator.ts
@@ -138,10 +138,14 @@ export const ValidatorOneof = (...options: (string | RegExp)[]) => {
 };
 
 export const ValidatorVolumeSize = (value: string) => {
-  if (!value) return undefined;
+  if (!value) return "Required";
 
   if (value === "Gi") {
     return "Required";
+  }
+
+  if (!value.match(new RegExp(`(^\\d+(\\.\\d+)?)([eEinumkKMGTP]*[-+]?[0-9]*)$`)) || value === "0Gi") {
+    return "Invalid Value";
   }
   // if (!value.match(/^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$/) || value === "0") {
   //   return "Invalid Value";


### PR DESCRIPTION
Current /volumes api Capacity using string unit, but it will lose precision.
For example: `0.1Gi` in Component volumes is `107374182400m`, but in /volumes API is `107374183`, so change the unit same as component volumes using Quantity
![image](https://user-images.githubusercontent.com/4652410/93187367-50abf300-f772-11ea-9483-b776c1dacb07.png)

After fixed:

![image](https://user-images.githubusercontent.com/4652410/93188042-14c55d80-f773-11ea-970e-3cf179b85783.png)
